### PR TITLE
Clamp image position to avoid showing empty areas

### DIFF
--- a/src/reference_viewer.lua
+++ b/src/reference_viewer.lua
@@ -104,6 +104,13 @@ ReferenceViewer.createViewer = function(title)
 				-- Updates the value of the slider with the actual value of scale_factor.
 				dlg:modify{id="scale_slider", value=scale_factor*100}
 
+                -- Clamp image position to avoid showing empty areas.
+                local min_display_pixels = 2 * inv_scale_factor
+                image_pos.x = math.max(image_pos.x, -gc.width * inv_scale_factor + min_display_pixels)
+                image_pos.x = math.min(image_pos.x, active_image.width - min_display_pixels)
+                image_pos.y = math.max(image_pos.y, -gc.height * inv_scale_factor + min_display_pixels)
+                image_pos.y = math.min(image_pos.y, active_image.height - min_display_pixels)
+
 				local image
 				-- When we zoom-in (scale_factor > fit_scale) we only
 				-- see a part of the image. We only copy what is visible


### PR DESCRIPTION
To prevent images from moving off-screen when users drag and zoom them, I have implemented clamping for `image_pos`.

notes: 
- Implementation within `onmousemove` was avoided because the `GraphicsContext` is hard to be obtained.
- Not adjusted `image_origin` because the displacement of the grab position seems unsettling.

### sample file
[reference_viewer-v0.5.3.zip](https://github.com/user-attachments/files/22983060/reference_viewer-v0.5.3.zip)

### preview
https://github.com/user-attachments/assets/2ffc81fc-c7f9-40a1-90e3-39e5f9cfafcc
